### PR TITLE
fix : webpack 버전 업으로 인한 속셩 수정

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -6,6 +6,6 @@ module.exports = defineConfig({
     client: {
       overlay: false,
     },
-    disableHostCheck: true,
+    allowedHosts: 'all',
   },
 });


### PR DESCRIPTION
webpack-dev-server@4부터는 allowedHosts 속성을 사용한다고 한다.

Resolves: #issueNo
See also: #issueNo